### PR TITLE
Align login page style with preview layout

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -21,26 +21,26 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-between py-8 px-4">
+    <div className="min-h-screen flex flex-col items-center justify-between py-20 px-4 bg-white dark:bg-zinc-900">
       <header className="flex flex-col items-center gap-2">
         <Image src="/umce-logo.png" alt="UMCE" width={80} height={80} />
-        <h1 className="text-2xl font-semibold">AcompañaUMCE</h1>
-        <span className="text-sm text-gray-500">Versión Beta</span>
+        <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">AcompañaUMCE</h1>
+        <span className="text-sm text-zinc-500 dark:text-zinc-400">Versión Beta</span>
       </header>
 
       <main className="flex flex-col items-center gap-6">
-        <p className="text-lg">Bienvenido a AcompañaUMCE</p>
+        <p className="text-lg text-zinc-700 dark:text-zinc-300">Bienvenido a AcompañaUMCE</p>
         <button
           onClick={handleLogin}
-          className="flex items-center gap-2 bg-white border rounded-lg px-6 py-3 shadow hover:bg-gray-50"
+          className="flex items-center gap-2 bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-lg px-6 py-3 shadow hover:bg-zinc-50 dark:hover:bg-zinc-700"
         >
           <Image src="/google-logo.png" alt="Google" width={20} height={20} />
-          <span className="font-medium">Iniciar sesión con Google</span>
+          <span className="font-medium text-zinc-700 dark:text-zinc-100">Iniciar sesión con Google</span>
         </button>
         {message && <p className="text-red-600 mt-4 text-sm text-center">{message}</p>}
       </main>
 
-      <footer className="text-xs text-center text-gray-500 mt-8">
+      <footer className="text-xs text-center text-zinc-500 dark:text-zinc-400 mt-8">
         Plataforma desarrollada por la Unidad de Desarrollo y Formación Virtual –
         UDFV. Contacto: <a href="mailto:udfv@umce.cl" className="underline">udfv@umce.cl</a>
       </footer>


### PR DESCRIPTION
## Summary
- update login page styling to match preview page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688bf0188b28832c9f4b7dfc76d746df